### PR TITLE
fix: support anonymous inner classes

### DIFF
--- a/src/main/java/com/github/havardh/javaflow/phases/parser/java/ClassVisitor.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/parser/java/ClassVisitor.java
@@ -81,7 +81,9 @@ public class ClassVisitor extends VoidVisitorAdapter<ClassBuilder> {
     super.visit(method, builder);
     TypeFactory factory = new TypeFactory(packageName, imports);
 
-    if (isClass((ClassOrInterfaceDeclaration) method.getParentNode()) && isGetter(method.getName(), method.getType().toString())) {
+    if (method.getParentNode() instanceof ClassOrInterfaceDeclaration
+        && isClass((ClassOrInterfaceDeclaration) method.getParentNode())
+        && isGetter(method.getName(), method.getType().toString())) {
       builder.withGetter(new Method(
           method.getName(),
           factory.build(method.getType().toString(), method.getType() instanceof PrimitiveType)
@@ -93,8 +95,7 @@ public class ClassVisitor extends VoidVisitorAdapter<ClassBuilder> {
     return field.getAnnotations().stream()
         .map(AnnotationExpr::getName)
         .map(NameExpr::getName)
-        .filter(name -> name.equals("Nullable"))
-        .count() > 0;
+        .anyMatch(name -> name.equals("Nullable"));
   }
 
   private boolean isClass(ClassOrInterfaceDeclaration classOrInterfaceDeclaration) {

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -164,6 +164,23 @@ public class ExecutionIntegrationTest {
   }
 
   @Test
+  public void shouldParseModelWithAnonymousClass() {
+    String flowCode = execution.run(
+        BASE_PATH + "ModelWithAnonymousClass.java",
+        BASE_PATH + "Member.java"
+    );
+
+    assertStringEqual(
+        flowCode,
+        "export type Member = {};",
+        "",
+        "export type ModelWithAnonymousClass = {",
+        "  field: Member,",
+        "};"
+    );
+  }
+
+  @Test
   public void shouldParseModelWithPrimitive() {
     String flowCode = execution.run(BASE_PATH + "ModelWithPrimitive.java");
 

--- a/src/test/java/com/github/havardh/javaflow/model/ModelWithAnonymousClass.java
+++ b/src/test/java/com/github/havardh/javaflow/model/ModelWithAnonymousClass.java
@@ -1,0 +1,15 @@
+package com.github.havardh.javaflow.model;
+
+public class ModelWithAnonymousClass {
+  private Member field = new Member() {
+    @Override
+    public String toString() {
+      return "Custom";
+    }
+  };
+
+  public Member getField() {
+    return field;
+  }
+}
+


### PR DESCRIPTION
This fixes an issue where having a field like

```java
private Member field = new Member() {
    @Override
    public String toString() {
      return "Custom";
    }
  };
```

would throw `java.lang.ClassCastException: com.github.javaparser.ast.expr.ObjectCreationExpr cannot be cast to com.github.javaparser.ast.body.ClassOrInterfaceDeclaration`