### PR TITLE
feat: support inner classes

### DIFF
--- a/src/main/java/com/github/havardh/javaflow/Execution.java
+++ b/src/main/java/com/github/havardh/javaflow/Execution.java
@@ -131,9 +131,7 @@ public class Execution {
    */
   private List<Type> parse(List<String> files) {
     return files.stream()
-        .map(parser::parse)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(source -> parser.parse(source).stream())
         .collect(toList());
   }
 

--- a/src/main/java/com/github/havardh/javaflow/ast/Class.java
+++ b/src/main/java/com/github/havardh/javaflow/ast/Class.java
@@ -14,6 +14,7 @@ import com.github.havardh.javaflow.util.Lists;
 public class Class extends Type {
 
   private final Parent parent;
+  private final List<Class> innerClasses;
   private final List<Field> fields;
   private final List<Method> getters;
 
@@ -23,14 +24,24 @@ public class Class extends Type {
    *
    * @param name the name of the class
    * @param parent optional parent of the type
+   * @param innerClasses the list of inner classes
    * @param fields the list of member fields
    * @param getters the list of getters in the class
    */
-  public Class(CanonicalName name, Parent parent, List<Field> fields, List<Method> getters) {
+  public Class(CanonicalName name, Parent parent, List<Class> innerClasses, List<Field> fields, List<Method> getters) {
     super(name);
     this.parent = parent;
+    this.innerClasses = innerClasses;
     this.fields = fields;
     this.getters = getters;
+  }
+
+  /**
+   * Get list of {@code Class} which are inner classes
+   * @return list of inner classes
+   */
+  public List<Class> getInnerClasses() {
+    return innerClasses;
   }
 
   /**

--- a/src/main/java/com/github/havardh/javaflow/ast/builders/ClassBuilder.java
+++ b/src/main/java/com/github/havardh/javaflow/ast/builders/ClassBuilder.java
@@ -7,6 +7,7 @@ import com.github.havardh.javaflow.ast.Class;
 import com.github.havardh.javaflow.ast.Field;
 import com.github.havardh.javaflow.ast.Method;
 import com.github.havardh.javaflow.ast.Parent;
+import com.github.havardh.javaflow.ast.Type;
 import com.github.havardh.javaflow.model.CanonicalName;
 
 /**
@@ -17,6 +18,7 @@ public class ClassBuilder implements Builder<Class> {
   private String packageName;
   private String name;
   private Parent parent;
+  private List<Class> innerClasses = new ArrayList<>();
   private List<Field> fields = new ArrayList<>();
   private List<Method> getters = new ArrayList<>();
 
@@ -66,6 +68,17 @@ public class ClassBuilder implements Builder<Class> {
   }
 
   /**
+   * Add an inner {@code Class} to class builder
+   *
+   * @param innerClass an inner {@code Class}
+   * @return the builder for method chaining
+   */
+  public ClassBuilder withInnerClass(Class innerClass) {
+    this.innerClasses.add(innerClass);
+    return this;
+  }
+
+  /**
    * Add a {@code Field} to class builder
    *
    * @param field a {@code Field}
@@ -92,7 +105,7 @@ public class ClassBuilder implements Builder<Class> {
    * @return the {@code Class}
    */
   public Class build() {
-    return new Class(CanonicalName.object(packageName, name), parent, fields, getters);
+    return new Class(CanonicalName.object(packageName, name), parent, innerClasses, fields, getters);
   }
 
 }

--- a/src/main/java/com/github/havardh/javaflow/phases/parser/Parser.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/parser/Parser.java
@@ -1,6 +1,6 @@
 package com.github.havardh.javaflow.phases.parser;
 
-import java.util.Optional;
+import java.util.List;
 
 import com.github.havardh.javaflow.ast.Type;
 
@@ -13,11 +13,11 @@ import com.github.havardh.javaflow.ast.Type;
 public interface Parser {
 
   /**
-   * Parse the given source code into a {@code Type}.
+   * Parse the given source code into a list of {@code Type} objects.
    *
    * @param sourceCode the source to parse
-   * @return the parsed source as a {@code Type}
+   * @return the parsed source as a {@code List<Type>}
    */
-  Optional<Type> parse(String sourceCode);
+  List<Type> parse(String sourceCode);
 }
 

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -206,6 +206,35 @@ public class ExecutionIntegrationTest {
   }
 
   @Test
+  public void shouldParseModelWithInnerClasses() {
+    String flowCode = execution.run(BASE_PATH + "ModelWithInnerClasses.java");
+
+    assertStringEqual(
+        flowCode,
+        "export type ModelWithInnerClasses = {",
+        "  child1: Child1,",
+        "  child2: Child2,",
+        "  child3: Child3,",
+        "  child4: Child4,",
+        "};",
+        "",
+        "export type Child1 = {};",
+        "",
+        "export type Child2 = {",
+        "  field1: number,",
+        "};",
+        "",
+        "export type Child3 = {",
+        "  field1: string,",
+        "};",
+        "",
+        "export type Child4 = {",
+        "  field1: string,",
+        "};"
+    );
+  }
+
+  @Test
   public void shouldParseModelWithPrimitive() {
     String flowCode = execution.run(BASE_PATH + "ModelWithPrimitive.java");
 

--- a/src/test/java/com/github/havardh/javaflow/JavaFlowTest.java
+++ b/src/test/java/com/github/havardh/javaflow/JavaFlowTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -339,7 +341,8 @@ public class JavaFlowTest {
   private static Type parse(String name) {
     return new FileReader().read(BASE_PATH + name + ".java")
         .map(new JavaParser()::parse)
-        .map(Optional::get)
+        .filter(result -> !result.isEmpty())
+        .map(result -> result.get(0))
         .orElse(null);
   }
 
@@ -352,9 +355,8 @@ public class JavaFlowTest {
         .map(name -> BASE_PATH + name + ".java")
         .map(adapter::read)
         .map(Optional::get)
-        .map(parser::parse)
-        .map(Optional::get)
-        .collect(toList());
+        .flatMap(source -> parser.parse(source).stream())
+        .collect(Collectors.toList());
 
     transformer.transform(types);
 

--- a/src/test/java/com/github/havardh/javaflow/model/ModelWithInnerClasses.java
+++ b/src/test/java/com/github/havardh/javaflow/model/ModelWithInnerClasses.java
@@ -1,0 +1,49 @@
+package com.github.havardh.javaflow.model;
+
+import com.github.havardh.javaflow.model.ModelWithInnerClasses.Child1.Child2;
+import com.github.havardh.javaflow.model.ModelWithInnerClasses.Child1.Child2.Child3;
+import com.github.havardh.javaflow.model.ModelWithInnerClasses.Child1.Child2.Child4;
+
+public class ModelWithInnerClasses {
+  class Child1 {
+    class Child2 {
+      class Child3 {
+        private String field1;
+
+        public String getField1() {
+          return field1;
+        }
+      }
+
+      class Child4 extends Child3 {
+      }
+
+      private int field1;
+
+      public int getField1() {
+        return field1;
+      }
+    }
+  }
+
+  private Child1 child1;
+  private Child2 child2;
+  private Child3 child3;
+  private Child4 child4;
+
+  public Child1 getChild1() {
+    return child1;
+  }
+
+  public Child2 getChild2() {
+    return child2;
+  }
+
+  public Child3 getChild3() {
+    return child3;
+  }
+
+  public Child4 getChild4() {
+    return child4;
+  }
+}


### PR DESCRIPTION
This is the biggest of the PRs and I think the last one for now :)

It enables support for inner classes, so constructs like this:

```java
public class ModelWithInnerClasses {
  class Child1 {
    private int field1;

    public int getField1() {
      return field1;
    }
  }

  private Child1 child1;

  public Child1 getChild1() {
    return child1;
  }
}
```

I needed to change some code, especially the `Parser` class to return a list of `Type`s now instead of a single type, but I think overall the changes are not too big. Just let me know what you think!