### PR TITLE
feat: update javaparser dependency to 3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ uploadArchives {
 }
 
 dependencies {
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'2.5.1'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version:'3.7.0'
     compile group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version:'1.08'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.7'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'

--- a/src/main/java/com/github/havardh/javaflow/phases/parser/java/EnumVisitor.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/parser/java/EnumVisitor.java
@@ -16,21 +16,21 @@ public class EnumVisitor extends VoidVisitorAdapter<EnumBuilder> {
   @Override
   public void visit(PackageDeclaration n, EnumBuilder builder) {
     super.visit(n, builder);
-    builder.withPackageName(n.getPackageName());
+    builder.withPackageName(n.getNameAsString());
   }
 
   /** {@inheritDoc} */
   @Override
   public void visit(EnumDeclaration n, EnumBuilder builder) {
     super.visit(n, builder);
-    builder.withName(n.getName());
+    builder.withName(n.getNameAsString());
   }
 
   /** {@inheritDoc} */
   @Override
   public void visit(EnumConstantDeclaration n, EnumBuilder builder) {
     super.visit(n, builder);
-    builder.withEnumValue(n.getName());
+    builder.withEnumValue(n.getNameAsString());
   }
 
 }

--- a/src/main/java/com/github/havardh/javaflow/phases/parser/java/JavaParser.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/parser/java/JavaParser.java
@@ -15,7 +15,8 @@ import com.github.havardh.javaflow.ast.builders.Builder;
 import com.github.havardh.javaflow.exceptions.ExitException;
 import com.github.havardh.javaflow.exceptions.ExitException.ErrorCode;
 import com.github.havardh.javaflow.phases.parser.Parser;
-import com.github.javaparser.ParseException;
+
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
@@ -50,7 +51,7 @@ public class JavaParser implements Parser {
     try {
       CompilationUnit cu = com.github.javaparser.JavaParser.parse(new StringReader(source));
       return convert(cu);
-    } catch (ParseException e) {
+    } catch (ParseProblemException e) {
       throw new ExitException(ErrorCode.COULD_NOT_PARSE_SOURCE_CODE, e);
     }
   }

--- a/src/main/java/com/github/havardh/javaflow/phases/parser/java/TypeFactory.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/parser/java/TypeFactory.java
@@ -117,7 +117,7 @@ public class TypeFactory {
 
   private static String extractValueType(String typeLiteral) {
     int index = typeLiteral.indexOf(",");
-    return typeLiteral.substring(index+2, typeLiteral.length() - 1);
+    return typeLiteral.substring(index + 1, typeLiteral.length() - 1).trim();
   }
 
   private static String extractArrayType(String typeLiteral) {

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -70,6 +70,20 @@ public class ExecutionIntegrationTest {
   }
 
   @Test
+  public void shouldParseModelWithFieldComments() {
+    String flowCode = execution.run(BASE_PATH + "ModelWithFieldComments.java");
+
+    assertStringEqual(
+        flowCode,
+        "export type ModelWithFieldComments = {",
+        "  field1: string,",
+        "  field2: string,",
+        "  field3: string,",
+        "};"
+    );
+  }
+
+  @Test
   public void shouldParseModelWithList() {
     String flowCode = execution.run(BASE_PATH + "ModelWithList.java");
 

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -79,6 +79,7 @@ public class ExecutionIntegrationTest {
         "  field1: string,",
         "  field2: string,",
         "  field3: string,",
+        "  field4: string,",
         "};"
     );
   }

--- a/src/test/java/com/github/havardh/javaflow/model/ModelWithFieldComments.java
+++ b/src/test/java/com/github/havardh/javaflow/model/ModelWithFieldComments.java
@@ -1,0 +1,24 @@
+package com.github.havardh.javaflow.model;
+
+public class ModelWithFieldComments {
+  // comment on field1
+  private String field1;
+
+  /* comment on field2 */
+  private String field2;
+
+  /** comment on field3 */
+  private String field3;
+
+  public String getField1() {
+    return field1;
+  }
+
+  public String getField2() {
+    return field2;
+  }
+
+  public String getField3() {
+    return field3;
+  }
+}

--- a/src/test/java/com/github/havardh/javaflow/model/ModelWithFieldComments.java
+++ b/src/test/java/com/github/havardh/javaflow/model/ModelWithFieldComments.java
@@ -1,5 +1,7 @@
 package com.github.havardh.javaflow.model;
 
+import javax.annotation.Generated;
+
 public class ModelWithFieldComments {
   // comment on field1
   private String field1;
@@ -9,6 +11,10 @@ public class ModelWithFieldComments {
 
   /** comment on field3 */
   private String field3;
+
+  @Generated("to test dangling javadoc comments")
+  /** comment on field4 */
+  private String field4;
 
   public String getField1() {
     return field1;
@@ -20,5 +26,9 @@ public class ModelWithFieldComments {
 
   public String getField3() {
     return field3;
+  }
+
+  public String getField4() {
+    return field4;
   }
 }


### PR DESCRIPTION
I do have one more PR 😇

Everything is working fine except for 1 thing: We have some comments and JavaDoc on fields:

```java
/** This is some field */
private String someField;
```

Unfortunately, there is an option in _javaparser_ to skip fields on comments, but not for javadoc comments: [DumpVisitor.java:410](https://github.com/javaparser/javaparser/blob/javaparser-parent-2.5.1/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/DumpVisitor.java#L410)

It is fixed in a later version, so I tried switching to the latest javaparser version (3.7.0) and after fixing some things everything seems to work. Due to the really good test coverage, this was actually much less work than I thought in the beginning, this is really nice! 👍

I have a good feeling about this and for our code base the type generation is working now, but as it's a big change please have a good look and tell me what you think about it! :)