### PR TITLE
fix: convert wildcard type params to "any"

### DIFF
--- a/src/main/java/com/github/havardh/javaflow/model/TypeMap.java
+++ b/src/main/java/com/github/havardh/javaflow/model/TypeMap.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +50,10 @@ public class TypeMap implements Map<String, String> {
     } catch (IOException e) {
       throw new ExitException(ErrorCode.COULD_NOT_PARSE_TYPE_MAP, e);
     }
+  }
+
+  public static TypeMap of(String k1, String v1) {
+    return new TypeMap(Collections.singletonMap(k1, v1));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/github/havardh/javaflow/phases/writer/flow/converter/JavaFlowConverter.java
+++ b/src/main/java/com/github/havardh/javaflow/phases/writer/flow/converter/JavaFlowConverter.java
@@ -42,6 +42,10 @@ public final class JavaFlowConverter implements Converter {
   }
 
   private static String getOrDefault(String name, String defaultName) {
+    if (name.equals("?") || name.endsWith(".?")) {
+      return "any";
+    }
+
     if (Objects.isObject(name)) {
       return Objects.get(name);
     }

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static com.github.havardh.javaflow.model.TypeMap.emptyTypeMap;
 import static com.github.havardh.javaflow.testutil.Assertions.assertStringEqual;
 
+import com.github.havardh.javaflow.model.TypeMap;
 import com.github.havardh.javaflow.phases.resolver.FileResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ public class ExecutionIntegrationTest {
 
   @BeforeEach
   public void setup() {
+    TypeMap typeMap = TypeMap.of("?", "any");
     this.execution = new Execution(
         new FileResolver(),
         new FileReader(),
@@ -41,8 +43,8 @@ public class ExecutionIntegrationTest {
             new InheritanceTransformer(),
             new SortedTypeTransformer()
         ),
-        asList(new MemberFieldsPresentVerifier(emptyTypeMap()), new ClassGetterNamingVerifier()),
-        new FlowWriter(new JavaFlowConverter()),
+        asList(new MemberFieldsPresentVerifier(typeMap), new ClassGetterNamingVerifier()),
+        new FlowWriter(new JavaFlowConverter(typeMap)),
         emptyList()
     );
   }

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -303,6 +303,19 @@ public class ExecutionIntegrationTest {
   }
 
   @Test
+  public void shouldParseModelWithWildcardTypeParams() {
+    String flowCode = execution.run(BASE_PATH + "ModelWithWildcardTypeParams.java");
+
+    assertStringEqual(
+        flowCode,
+        "export type ModelWithWildcardTypeParams = {",
+        "  wildcardList: Array<any>,",
+        "  wildcardMap: {[key: any]: Array<any>},",
+        "};"
+    );
+  }
+
+  @Test
   public void shouldThrowExceptionWhenFieldIsNotFound() {
     try {
       execution.run(BASE_PATH + "Wrapper.java");

--- a/src/test/java/com/github/havardh/javaflow/model/ModelWithWildcardTypeParams.java
+++ b/src/test/java/com/github/havardh/javaflow/model/ModelWithWildcardTypeParams.java
@@ -1,0 +1,18 @@
+package com.github.havardh.javaflow.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ModelWithWildcardTypeParams {
+  private List<?> wildcardList;
+  private Map<?, Set<?>> wildcardMap;
+
+  public List<?> getWildcardList() {
+    return wildcardList;
+  }
+
+  public Map<?, Set<?>> getWildcardMap() {
+    return wildcardMap;
+  }
+}


### PR DESCRIPTION
Please don't ask me why, but we do have fields like `private List<?> list` in our model and changing them was actually more effort than I thought :)

Not 100 % sure about the implementation, maybe we need another class `Wildcards` instead of adding the check directly in JavaFlowConverter, but I thought that might be too much.