### PR TITLE
fix: match types by name in addition to canonical name

### DIFF
--- a/src/main/java/com/github/havardh/javaflow/model/TypeMap.java
+++ b/src/main/java/com/github/havardh/javaflow/model/TypeMap.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +50,10 @@ public class TypeMap implements Map<String, String> {
     } catch (IOException e) {
       throw new ExitException(ErrorCode.COULD_NOT_PARSE_TYPE_MAP, e);
     }
+  }
+
+  public static TypeMap of(String k1, String v1) {
+    return new TypeMap(Collections.singletonMap(k1, v1));
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
+++ b/src/test/java/com/github/havardh/javaflow/ExecutionIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static com.github.havardh.javaflow.model.TypeMap.emptyTypeMap;
 import static com.github.havardh.javaflow.testutil.Assertions.assertStringEqual;
 
+import com.github.havardh.javaflow.model.TypeMap;
 import com.github.havardh.javaflow.phases.resolver.FileResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ public class ExecutionIntegrationTest {
 
   @BeforeEach
   public void setup() {
+    TypeMap typeMap = TypeMap.of("?", "any");
     this.execution = new Execution(
         new FileResolver(),
         new FileReader(),
@@ -41,8 +43,8 @@ public class ExecutionIntegrationTest {
             new InheritanceTransformer(),
             new SortedTypeTransformer()
         ),
-        asList(new MemberFieldsPresentVerifier(emptyTypeMap()), new ClassGetterNamingVerifier()),
-        new FlowWriter(new JavaFlowConverter()),
+        asList(new MemberFieldsPresentVerifier(typeMap), new ClassGetterNamingVerifier()),
+        new FlowWriter(new JavaFlowConverter(typeMap)),
         emptyList()
     );
   }


### PR DESCRIPTION
Allows types to be overriden by custom type substitution on the type name. This
allows the ? java wildcard type to be overriden to `any` by adding `?: any` to
the types.yml file.

@pascalgn: What about this approach? It will look up custom type substitutions based on both the canonical name, and the simple name of each unknown class. This allows us to both override the cases for `com.example.?` and any `?` with preference on the most specific match. 